### PR TITLE
Bump the timeout to 12 seconds now that the log endpoint waits 10 sec…

### DIFF
--- a/common/alert.go
+++ b/common/alert.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultTimeout = 2 * time.Second
+	defaultTimeout = 12 * time.Second
 )
 
 func SendAlert(alert io.Reader, url string) error {


### PR DESCRIPTION
…onds to check for OOM node.